### PR TITLE
fix: Rename variable

### DIFF
--- a/casino/games/roulette/roulette.py
+++ b/casino/games/roulette/roulette.py
@@ -361,7 +361,7 @@ def play_roulette(contexts : List[GameContext]) -> None:
     contexts = [contexts]
 
     # Access account data
-    accounts = [account.account for account in accounts]
+    accounts = [account.account for account in contexts]
 
     if type(accounts) != list:
         raise ValueError(f"accounts is not a list. accounts is a {type(accounts)}")


### PR DESCRIPTION
Very SMALL PR.

I forgot to rename one of the variables from `accounts` to `contexts` in `play_roulette()`. This change ensures the `roulette.py` will work now.