### PR TITLE
Implement insurance mechanic in Blackjack (#83)

### DIFF
--- a/casino/games/blackjack/blackjack.py
+++ b/casino/games/blackjack/blackjack.py
@@ -128,6 +128,66 @@ def display_blackjack_topbar(ctx: GameContext, bet: Optional[int]) -> None:
         cprint(f"Bet: {bet}")
 
 
+def offer_insurance(ctx, bet, dealer_hand, player_hand, account):
+    """Offers insurance when dealer shows Ace."""
+    upcard = dealer_hand[0]
+    if upcard.rank != "A":
+        return 0, False
+    
+    # display hands
+    cprint("Dealer hand:")
+    print_hand(dealer_hand, hidden=True)
+    cprint("Your hand:")
+    print_hand(player_hand)
+
+    cprint("Dealer shows an Ace.")
+    cprint("Would you like to buy insurance?")
+
+    choice = cinput(YES_OR_NO_PROMPT)
+    while choice not in "YyNn" or choice == "":
+        clear_screen()
+        display_blackjack_topbar(ctx, bet)
+        cprint(INVALID_YES_OR_NO)
+        choice = cinput(YES_OR_NO_PROMPT)
+
+    while choice in "Yy":
+        max_bet = bet // 2
+        insurance_bet_str = cinput(f"You can bet up to {max_bet} chips. How much would you like to bet for insurance?").strip()
+        insurance_bet = 0
+        try:
+            insurance_bet = int(insurance_bet_str)
+            if insurance_bet > max_bet:
+                cprint(f"The maximum bet is {max_bet} chips.")
+                continue
+        except ValueError:
+            cprint(INVALID_BET_MSG)
+            continue
+        try:
+            account.withdraw(insurance_bet)
+        except ValueError:
+            cprint(f"Insufficient funds. You only have {account.balance} chips.")
+            continue
+        return insurance_bet, True # success
+
+    return 0, False
+
+def resolve_insurance_win(account, insurance_bet, insurance_taken):
+    """Payout 2:1 insurance if dealer has blackjack."""
+    if insurance_taken and insurance_bet > 0:
+        # payout = return bet + 2× profit
+        account.deposit(insurance_bet * 3)
+        return f"Insurance pays out: +{insurance_bet * 2} chips\n"
+    else:
+        return ""
+
+def resolve_insurance_loss(insurance_bet, insurance_taken):
+    """Player loses insurance immediately when dealer does not have blackjack."""
+    if insurance_taken and insurance_bet > 0:
+        return f"You lose your insurance bet: -{insurance_bet} chips\n"
+    else:
+        return ""
+
+
 def play_blackjack(ctx: GameContext) -> None:
     """Play a blackjack game."""
     account = ctx.account
@@ -204,6 +264,8 @@ def play_blackjack(ctx: GameContext) -> None:
             deal_card(player_hand, deck)
             deal_card(dealer_hand, deck)
 
+        insurance_bet, insurance_taken = offer_insurance(ctx, bet, dealer_hand, player_hand, account)
+
         # player BJ check
         if hand_total(player_hand) == 21:
             player_bj = True
@@ -215,7 +277,7 @@ def play_blackjack(ctx: GameContext) -> None:
             dealer_bj = True
             player_status = False
             dealer_status = False
-            cprint("Your hand:")
+            cprint("Dealer hand:")
             print_hand(dealer_hand)
             cprint("Your hand:")
             print_hand(player_hand)
@@ -297,6 +359,14 @@ def play_blackjack(ctx: GameContext) -> None:
         player_won = False
         dealer_won = False
         win_msgs = []
+        # insurance resolution
+        if dealer_bj:
+            insurance_msg = resolve_insurance_win(account, insurance_bet, insurance_taken)
+            win_msgs.append(insurance_msg)
+        else:
+            insurance_msg = resolve_insurance_loss(insurance_bet, insurance_taken)
+            win_msgs.append(insurance_msg)
+        # main game resolution
         if player_bj and dealer_bj:
             win_msgs.append("Player and dealer have a blackjack\n")
             win_msgs.append("Push\n")


### PR DESCRIPTION
Completed Issue #83
This PR implements the insurance mechanic in the blackjack game following the American ruleset.

- Added `offer_insurance()` function to prompt the player for insurance.
- Added `resolve_insurance_win()` and `resolve_insurance_loss()` to handle payouts or losses.

Please let me know if any changes or improvements are needed. Thank you!