### PR TITLE
Fixed Issue #112 - Popping from empty deck error

### DIFF
--- a/casino/games/poker/poker.py
+++ b/casino/games/poker/poker.py
@@ -479,6 +479,8 @@ def play_poker(ctx: GameContext) -> None:
             opponent_chips += pot
             cprint(f"Your balance: {account.balance} chips\n")
         
+        # Regenerate the deck (i.e. return all cards to deck and shuffle)
+        deck.generate_deck()
         
         # game restart?
         if account.balance < 20: # The starting bet pre-flop


### PR DESCRIPTION
Added code at the end of each poker game to regenerate the deck. This way we simulate the action of returning all cards to deck and reshuffling before starting a new game, and we eliminate the error of running out of cards in the deck to draw from. 