### PR TITLE
Added Double Down and fixed multiple bugs in new OOP Blackjack

### DIFF
--- a/casino/games/blackjack/blackjack.py
+++ b/casino/games/blackjack/blackjack.py
@@ -1,4 +1,5 @@
 import random
+import sys
 from typing import Optional, List
 from abc import ABC, abstractmethod
 from time import sleep
@@ -53,6 +54,7 @@ class Player:
         self.bet = 0
 
         # Special flags
+        self.initial_hand: bool = True
         self.has_blackjack: bool = False
         self.skip: bool = False
 
@@ -120,6 +122,7 @@ class Blackjack(ABC):
 
         self.players: List[Player] = []
         self.dealer: Dealer = Dealer()
+        self.round_results: List[str] = []
 
         # Define a single player
         # NOTE: This must be updated if local multiplayer is added
@@ -154,10 +157,17 @@ class Blackjack(ABC):
 
         # TODO: Refactor so that this function works for multiple players
         for player in self.players:
+
+            # Kick from casino if player has 0 chips
+            if player.balance == 0:
+                clear_screen()
+                cprint("GAME OVER")
+                cprint("You have lost all your chips. Security is escorting you out.")
+                sys.exit()
             if player.balance < self.MINIMUM_BET:
                 cprint(NO_FUNDS_MSG)
                 cinput("Press [Enter] to continue")
-                return
+                return "EXIT"
 
             # Ask user if they would like to stay at the table  
             cprint(STAY_AT_TABLE_PROMPT)
@@ -196,21 +206,22 @@ class Blackjack(ABC):
         """
         pass
 
-    def reset(self, context = None):
+
+    def reset(self):
         """
-        Reset a Blackjack object.
-
-        This function is typically run in between rounds to reset the state of Blackjack
+        Resets the round state without destroying player objects.
         """
+        self.deck = StandardDeck()
+        self.dealer.hand = []
+        self.dealer.has_blackjack = False
+        self.player_win_status = [None] * len(self.players)
 
-        # Reset Blackjack with old configuration
-        if context == None:
-            self.__init__(self.context)
-
-        # Reset Blackjack but load a new configuration
-        else:
-            self.__init__(context)
-
+        for player in self.players:
+            player.hand = []
+            player.bet = 0
+            player.initial_hand = True
+            player.has_blackjack = False
+            player.skip = False
 
 class StandardBlackjack(Blackjack):
     def __init__(self, ctx: GameContext) -> None:
@@ -317,54 +328,93 @@ class StandardBlackjack(Blackjack):
         hidden  = self.dealer.hand[1]
         self.dealer.has_blackjack = face_up.rank == "A" and hidden.rank in [10, "J", "Q", "K"]
         
-    def player_decision(self) -> None | str:
+    def player_decision(self) -> str:
         """
-        Phase of blackjack where players make decision.
+        Phase where players make decisions. 
+        Handles Hit, Stand, Double Down, and Double for Less.
         """
         for i, player in enumerate(self.players):
-            # Players with win status of None have not won, lost, or drawn yet.
-            if self.player_win_status[i] != None:
+            if self.player_win_status[i] is not None:
                 continue
             
+            if player.hand_total == 21:
+                self.show_table_state(player)
+                if player.has_blackjack:
+                    cprint(f"!!! {player.name.upper()} HAS A NATURAL BLACKJACK !!!")
+                else:
+                    cprint(f"!!! {player.name.upper()} HAS 21 !!!")
+                sleep(2.0)
+                continue 
+                
             while True:
-                clear_screen()
-                self.display_blackjack_topbar()
-                cprint(f"Dealer Hand")
-                print_cards(self.dealer.hand)
-                cprint(f"Player Hand: {self.players[0].hand_total}")
-                print_cards(player.hand)
+                self.show_table_state(player)
+                
+                options = "[S]tay   [H]it"
+                can_double = player.initial_hand and player.balance > 0
+                
+                if can_double:
+                    if player.balance >= player.bet:
+                        options += "   [D]ouble Down"
+                    else:
+                        options += "   [D]ouble for Less"
+                
+                action = cinput(options).upper()
 
-                action = cinput(f"[S]tand   [H]it")
-                print()
-
-                # Check valid answer. If user surpasses `stubborn` threshold, call security
-                # and kick user out
-                stubborn = 0
-                while action.upper() not in {"S", "STAND", "H", "HIT"}:
-                    stubborn += 1
-                    if stubborn >= 13:
-                        return "kicked"
-
-                    clear_screen()
-                    self.display_blackjack_topbar(player.bet)
-                    cprint(INVALID_CHOICE_MSG + "\n")
-
-                    cprint("Dealer Hand:")
-                    print_cards(self.dealer.hand)
-                    cprint("Player Hand:")
-                    print_cards(player.hand)
-                    action = cinput("[S]tay   [H]it")
-
-                if action.upper() in {"S", "STAND"}:
+                if action in {"S", "STAND", "STAY"}:
                     break
-                elif action.upper() in {"H", "HIT"}:
+
+                elif action in {"H", "HIT"}:
                     card = self.deck.draw()
                     card.hidden = False
                     player.hand.append(card)
+                    player.initial_hand = False
 
-                    if player.hand_total > 21:
+                    if player.hand_total == 21:
+                        self.show_table_state(player)
+                        cprint(f"!!! {player.name.upper()} HIT 21 !!!")
+                        sleep(2.0)
+                        break 
+                    elif player.hand_total > 21:
                         self.player_win_status[i] = "lose"
                         break
+                
+                elif action in {"D", "DOUBLE", "DOUBLE DOWN", "DOUBLE FOR LESS"} and can_double:
+                    # Logic to determine how much extra we can actually take
+                    if player.balance >= player.bet:
+                        extra_bet = player.bet
+                        cprint(f"Doubling Down! Adding {extra_bet} to your bet.")
+                    else:
+                        extra_bet = player.balance
+                        cprint(f"Doubling for Less! Adding your remaining {extra_bet} to your bet.")
+                    
+                    player.balance -= extra_bet
+                    player.bet += extra_bet
+                    player.update_account()
+                    sleep(1.5)
+
+                    card = self.deck.draw()
+                    card.hidden = False
+                    player.hand.append(card)
+                    
+                    self.show_table_state(player)
+                    if player.hand_total == 21:
+                        cprint(f"!!! {player.name.upper()} DOUBLED TO 21 !!!")
+                        sleep(2.0)
+                    elif player.hand_total > 21:
+                        self.player_win_status[i] = "lose"
+                    
+                    break # Turn always ends after any double action
+
+        return "proceed"
+
+    def show_table_state(self, player: Player):
+        """Helper to maintain UI consistency across prompts and pauses."""
+        clear_screen()
+        self.display_blackjack_topbar(player.bet)
+        cprint("Dealer Hand:")
+        print_cards(self.dealer.hand)
+        cprint(f"Your Hand: {player.hand_total}")
+        print_cards(player.hand)
 
     def dealer_draw(self) -> None:
         """
@@ -444,7 +494,7 @@ class StandardBlackjack(Blackjack):
         Phase of blackjack where game checks who won and pays out to users.
         """
         
-        win_msgs: List[str] = []
+        self.round_results: List[str] = []
         dealer_won = False
 
         # Alias for quickly evaluating totals
@@ -485,12 +535,12 @@ class StandardBlackjack(Blackjack):
                 result = "player_wins"
 
             outcome_dict = self.outcome_msg(result, player.bet)
-            outcome_msg = outcome_dict["message"] + "\n" + outcome_dict["bet_result"]
+
+            formatted_bet_msg = outcome_dict["bet_result"].format(bet=player.bet)
+            full_outcome = f"{outcome_dict['message']}\n{formatted_bet_msg}"
 
             self.player_win_status[i] = win_status
-        
-            # Print final result to player
-            cprint(outcome_msg)
+            self.round_results.append(full_outcome)
 
     def payout(self):
         """
@@ -528,7 +578,7 @@ class StandardBlackjack(Blackjack):
         """
 
         # TODO: rework function so that it works for local multiplayer
-        for player in self.players:
+        for i, player in enumerate(self.players):
             clear_screen()
             self.display_blackjack_topbar(player.bet)
 
@@ -538,16 +588,15 @@ class StandardBlackjack(Blackjack):
             cprint(f"Your Hand: {player.hand_total}")
             print_cards(player.hand)
 
-        display_msg: dict[str, str] = {
-            "win": "You win!"
-        }
+            # Print the detailed message
+            cprint("\n" + "="*30)
+            cprint(self.round_results[i]) # This is the "Dealer wins / Player lose" text
+            cprint("="*30 + "\n")
 
-        for msg in self.player_win_status:
-            cprint(msg)
-
-            action: str | None = None
+            # Force the pause here so the user can actually read it
+            action = None
             while action != "":
-                action = cinput("Press [Enter] to leave Results")
+                action = cinput("Press [Enter] to continue...")
 
     def play_round(self) -> str:
         """
@@ -568,7 +617,7 @@ class StandardBlackjack(Blackjack):
         self.display_results()
 
         status: str = self.play_again()
-        return status
+        return status if status else "EXIT"
 
 
 def play_blackjack(context: GameContext):


### PR DESCRIPTION

**Closed Last PR to fix title typo**

Closes #115 

Fixed the NoneType AttributeError: resolved the crash in the main loop by ensuring play_round and play_again always return valid status strings instead of None

Fixed round end messages so that they actually print the outcome after each round instead of "win" or "lose"

Implemented Double Down and Double for Less logic to new OOP Blackjack

Updated the decision loop to contextually hide the "Double Down" option once a player has already hit or if they lack funds.

Corrected a hardcoded reference that forced the UI to always show "Player 1" totals, even if multiple players were theoretically active.

Integrated sleep() calls after 21s, blackjacks, busts, and doubles so the player has time to actually see the cards and messages before the screen clears.

Updated the reset() method to clear the table state while preserving the Account object, keeping the chip count accurate across long sessions.

Integrated a sys.exit() call that triggers a "Security Escort" message if a player hits 0 chips.