### PR TITLE
fix: re-center user input with dynamic per-keystroke centering

### DIFF
--- a/casino/main.py
+++ b/casino/main.py
@@ -134,7 +134,7 @@ def main():
     clear_screen()
     display_topbar(account=None, **CASINO_HEADER_OPTIONS)
 
-    name = cinput("Enter your name:").strip()
+    name = cinput("Enter your name: ").strip()
     while not name:
         clear_screen()
         display_topbar(account=None, **CASINO_HEADER_OPTIONS)

--- a/casino/utils.py
+++ b/casino/utils.py
@@ -155,12 +155,13 @@ def cinput(prompt: str = "") -> str:
             print()
             return text.strip()
         elif ch in ('\x08', '\x7f'):
-            text = text[:-1]
-            _print_centered_input(text, terminal_width)
+            if text:
+                text = text[:-1]
+                _print_centered_input(text, terminal_width)
         elif ch == '\x03':
             print()
             raise KeyboardInterrupt
-        elif ch in ('\x04', '\x1a'):
+        elif ch == '\x04' or (ch == '\x1a' and os.name != 'nt'):
             print()
             raise EOFError
         elif ch and ch.isprintable():


### PR DESCRIPTION
Replace static input() with character-by-character reading that re-centers text on every keystroke. Remove redundant .center() pre-processing of prompts in main.py.

Closes #142