### PR TITLE
added stats

### DIFF
--- a/casino/stats.py
+++ b/casino/stats.py
@@ -1,0 +1,67 @@
+from dataclasses import dataclass
+
+from .utils import cprint, cinput, clear_screen
+
+
+@dataclass
+class GameStats:
+    game_name: str
+    starting_balance: int
+    ending_balance: int = 0
+    rounds_played: int = 0
+    wins: int = 0
+    losses: int = 0
+    pushes: int = 0
+
+    @property
+    def net(self) -> int:
+        return self.ending_balance - self.starting_balance
+
+    @property
+    def win_rate(self) -> str:
+        if self.rounds_played == 0:
+            return "N/A"
+        return f"{self.wins / self.rounds_played * 100:.1f}%"
+
+
+def display_stats(stats: GameStats) -> None:
+    """Display a post-game session summary."""
+    clear_screen()
+
+    net = stats.net
+    net_str = f"+{net}" if net > 0 else str(net)
+
+    rows = [
+        ("Game", stats.game_name),
+        ("Hands Played", str(stats.rounds_played)),
+        ("Wins", str(stats.wins)),
+        ("Losses", str(stats.losses)),
+        ("Pushes", str(stats.pushes)),
+        ("Win Rate", stats.win_rate),
+        ("", ""),
+        ("Starting Balance", str(stats.starting_balance)),
+        ("Ending Balance", str(stats.ending_balance)),
+        ("Net Profit/Loss", net_str),
+    ]
+
+    label_width = max(len(r[0]) for r in rows)
+    value_width = max(len(r[1]) for r in rows)
+    inner_width = label_width + value_width + 6  # padding + colon + spaces
+    box_width = inner_width + 4  # borders + margin
+
+    title = " Session Summary "
+    side = (box_width - 2 - len(title)) // 2
+    top_border = f"┌{'─' * side}{title}{'─' * (box_width - 2 - side - len(title))}┐"
+    bot_border = f"└{'─' * (box_width - 2)}┘"
+
+    cprint(top_border)
+    for label, value in rows:
+        if label == "":
+            cprint(f"│{' ' * (box_width - 2)}│")
+        else:
+            line = f"  {label + ':':<{label_width + 1}}  {value:>{value_width}}  "
+            cprint(f"│{line}│")
+    cprint(bot_border)
+
+    cprint("")
+    cinput("Press Enter to return to menu...")


### PR DESCRIPTION
## Type of Change
 - [x ] Feature
 - [ ] Bug Fix
 - [ ] Update
 - [ ] Refactor
 - [ ] Other (please describe)

## Related Issue
Fixes issue [#114](issues/114) 

## Changes
*Describe any/all changes made to the repository.*
Added postgame stats feature as a summary screen that displays after a player leaves any supported game table. For now, this includes blackjack (US and EU), as well as poker. 

Added files: 
casino/stats.py: This is a new module containing the GameStats dataclass (tracks rounds played, wins, losses, pushes, starting/ending balance), as well as the display_stats() function which renders the summary box using cprint and cinput.

Edited files: 
casino/games/blackjack/blackjack.py
casino/games/blackjack/european.py
casino/games/poker/poker.py

Added stats initialization to all of these, including W/L/P tracking, outcome status, displaying stats


## Testing

Run py -m casino.main
Enter a name and select a theme
Play several hands of Blackjack (U.S.), then quit the table → verify session summary appears with correct counts and balance
Repeat for Blackjack (E.U.) and Poker
Verify the summary also appears when forced out due to insufficient funds

## Checklist
<!--- Leave items unchecked if they are not applicable --->
 - [ ] No merge conflicts
 - [X ] I self-reviewed my code
 - [X ] I added comments to make my code readable
 - [ ] I added tests to cover my changes
 - [X ] I have checked to see there are no open pull requests for the same issue

### Output Screenshots
<img width="704" height="503" alt="image" src="https://github.com/user-attachments/assets/6740095c-3526-462c-a3e3-4112d7bad247" />

### Next Steps
Next: Adding stats for the rest of the games, like slots and roulette. Then, adding more game-specific stats, like largest win margin or # of spins for slots. 
