### PR TITLE
Add postgame stats for UNO

### DIFF
--- a/casino/games/uno/uno.py
+++ b/casino/games/uno/uno.py
@@ -6,6 +6,7 @@ from .player import Player
 from casino.types import GameContext
 from casino.utils import clear_screen, cprint, cinput, display_topbar
 from casino.cards import UnoDeck, UnoCard
+from casino.stats import GameStats, display_stats
 
 UNO_HEADER = """
 ┌───────────────────────────────┐
@@ -96,6 +97,8 @@ def play_uno(ctx: GameContext) -> None:
     continueGame = True
     currentPlayerIndex = 0
     direction = 1
+    account = ctx.account
+    stats = GameStats("UNO", account.balance)
     while(continueGame) :
         i = players[currentPlayerIndex]
         current_card = discard[-1]
@@ -161,9 +164,12 @@ def play_uno(ctx: GameContext) -> None:
             i.hand.remove(new_card)
             if len(i.hand) == 0:
                 continueGame = False
+                stats.rounds_played += 1
+                stats.ending_balance = account.balance
                 display_uno_topbar(ctx)
                 cprint(f"{i.name} is the winner!")
                 cinput("Press enter when ready to exit")
+                display_stats(stats)
                 break
             match new_card.rank:
                 case "skip":


### PR DESCRIPTION
## Type of Change
<!--- type an 'x' into the brackets to select a listed option i.e. [ ] -> [x] --->
 - [x] Feature
 - [ ] Bug Fix
 - [ ] Update
 - [ ] Refactor
 - [ ] Other (please describe)

## Related Issue
<!--- replace XXs with the issue number --->
Fixes issue [#XX](issues/XX) 
#163 

## Changes
*Describe any/all changes made to the repository.*
Add postgame session summary for UNO game. Since the UNO game doesn't have account balance and win and loss mechanism like other game (e.g. slots/blackjack), I just incremented the rounds of game played and the game name in the gamestats.

Please include:
 - casino\games\uno\uno.py

*Explain why these changes were necessary.*

## Testing
*What steps were taken to test these changes?*

*If this is a bug fix, please provide steps to reproduce the bug*

## Checklist
<!--- Leave items unchecked if they are not applicable --->
 - [x] No merge conflicts
 - [x] I self-reviewed my code
 - [x] I have checked to see there are no open pull requests for the same issue

### Output Screenshots
<!--- Remove this section if it is not needed --->
If necessary, add screenshots of changes.

For example: visual updates, before/after a bugged output, new feature output

### Next Steps
<!--- Remove this section if it is not needed --->
What is there TODO following this pull request?

### AI Disclosure
<!--- Remove this section if it is not needed --->
To what degree did you use AI for this pull request? 
